### PR TITLE
Generate image tag name automatically based on xrdp version in apt repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 IMAGE=satishweb/xrdp
 PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 WORKDIR=$(shell pwd)
-#TAGNAME?=$(shell curl -s https://api.github.com/repos/xx/xx/tags|jq -r '.[0].name')
 TAGNAME?=devel
 ifdef PUSH
 	EXTRA_BUILD_PARAMS = --push-images --push-git-tags
@@ -16,6 +15,17 @@ ifdef NO-CACHE
 endif
 
 all:
+	TAGNAME=$$(set -x && \
+	docker run --rm --entrypoint=bash ubuntu:20.04 -c \
+		"set -x; echo 'deb http://archive.ubuntu.com/ubuntu/ focal universe' > /etc/apt/sources.list; \
+		apt update >/dev/null 2>&1; \
+		apt-cache madison xrdp \
+		|cut -d \| -f 2 \
+		|sed 's/ //g'" \
+	) ;\
+	${MAKE} build TAGNAME=$$TAGNAME
+
+build:
 	./build.sh \
 	  --image-name "${IMAGE}" \
 	  --platforms "${PLATFORMS}" \


### PR DESCRIPTION
### What is changed?
- Updated makefile to determine the xrdp version available in the apt repository
- Use the xrdp version as a docker image tag. 

### Why?
- Using the xrdp version as a docker image tag will make it easy to identify the correct docker image for a particular xrdp version
- Keeping image tags in sync with xrdp will allow automated CICD to function well